### PR TITLE
Default memories load fix

### DIFF
--- a/packages/sdk/sdk/src/default-components.tsx
+++ b/packages/sdk/sdk/src/default-components.tsx
@@ -249,16 +249,18 @@ const DefaultMemoriesInternal = () => {
     setDefaultMemoriesValue(value);
   };
 
-  return defaultMemoriesValue.length > 0 && (
+  return (
     <>
-      <Prompt>
-        {dedent`\
-          # Memories
-          Your character has the following in mind:
-          ` + '\n' +
-          JSON.stringify(defaultMemoriesValue, null, 2)
-        }
-      </Prompt>
+      {defaultMemoriesValue.length > 0 && (
+        <Prompt>
+          {dedent`\
+            # Memories
+            Your character has the following in mind:
+            ` + '\n' +
+            JSON.stringify(defaultMemoriesValue, null, 2)
+          }
+        </Prompt>
+      )}
       <EveryNMessages n={1}>{() => {
         refreshDefaultMemories();
       }}</EveryNMessages>


### PR DESCRIPTION
Fixes refreshDefaultMemories not being called on the initial construction of the default components. This was because it was guarded by the initial failure to have memories which doesn't really make sense. I think the intent of the code was to condition the prompt on the initial value, not the refresh.