### PR TITLE
Persist agent creation data local storage

### DIFF
--- a/apps/chat/app/new/editor.tsx
+++ b/apps/chat/app/new/editor.tsx
@@ -48,6 +48,7 @@ import {
   Currency,
   Interval,
 } from 'react-agents/types';
+import { base64ToBlob, blobToBase64 } from 'react-agents/util/base64.mjs';
 const ensureEsbuild = (() => {
   let esBuildPromise: Promise<void> | null = null;
   return () => {
@@ -207,19 +208,26 @@ export default function AgentEditor({
   user,
 }: AgentEditorProps) {
   // state
-  const [name, setName] = useState('');
-  const [bio, setBio] = useState('');
-  const [visualDescription, setVisualDescription] = useState('');
-  const [homespaceDescription, setHomespaceDescription] = useState('');
+  const [name, setName] = useState(localStorage.getItem('name') || '');
+  const [bio, setBio] = useState(localStorage.getItem('bio') || '');
+  const [visualDescription, setVisualDescription] = useState(localStorage.getItem('visualDescription') || '');
+  const [homespaceDescription, setHomespaceDescription] = useState(localStorage.getItem('homespaceDescription') || '');
 
   const [model, setModel] = useState(defaultModels[0]);
   const [visionModel, setVisionModel] = useState(defaultVisionModels[0]);
 
-  const [previewBlob, setPreviewBlob] = useState<Blob | null>(null);
-  const [previewUrl, setPreviewUrl] = useState('');
+  const [previewBlob, setPreviewBlob] = useState<Blob | null>(() => {
+    const base64 = localStorage.getItem('previewBlob');
+    return base64 ? base64ToBlob(base64) : null;
+  });
 
-  const [homespaceBlob, setHomespaceBlob] = useState<Blob | null>(null);
-  const [homespaceUrl, setHomespaceUrl] = useState('');
+  const [previewUrl, setPreviewUrl] = useState(localStorage.getItem('previewUrl') || '');
+
+  const [homespaceBlob, setHomespaceBlob] = useState<Blob | null>(() => {
+    const base64 = localStorage.getItem('homespaceBlob');
+    return base64 ? base64ToBlob(base64) : null;
+  });
+  const [homespaceUrl, setHomespaceUrl] = useState(localStorage.getItem('homespaceUrl') || '');
 
   const [deploying, setDeploying] = useState(false);
   const [room, setRoom] = useState('');
@@ -247,6 +255,52 @@ export default function AgentEditor({
   const [sourceCode, setSourceCode] = useState(() => makeAgentSourceCode(features));
 
   const monaco = useMonaco();
+
+  useEffect(() => {
+    console.log('set name', name);
+    localStorage.setItem('name', name);
+  }, [name]);
+
+  useEffect(() => {
+    localStorage.setItem('bio', bio);
+  }, [bio]);
+
+  useEffect(() => {
+    localStorage.setItem('visualDescription', visualDescription);
+  }, [visualDescription]);
+
+  useEffect(() => {
+    localStorage.setItem('homespaceDescription', homespaceDescription);
+  }, [homespaceDescription]);
+
+  useEffect(() => {
+    console.log('set previewUrl', previewUrl);
+    localStorage.setItem('previewUrl', previewUrl);
+  }, [previewUrl]);
+
+  useEffect(() => {
+    localStorage.setItem('homespaceUrl', homespaceUrl);
+  }, [homespaceUrl]);
+
+  useEffect(() => {
+    if (previewBlob) {
+      blobToBase64(previewBlob).then(base64 => {
+        localStorage.setItem('previewBlob', base64);
+      });
+    } else {
+      localStorage.removeItem('previewBlob');
+    }
+  }, [previewBlob]);
+
+  useEffect(() => {
+    if (homespaceBlob) {
+      blobToBase64(homespaceBlob).then(base64 => {
+        localStorage.setItem('homespaceBlob', base64);
+      });
+    } else {
+      localStorage.removeItem('homespaceBlob');
+    }
+  }, [homespaceBlob]);
 
   // useEffect(() => {
   //   (async () => {

--- a/apps/chat/app/new/editor.tsx
+++ b/apps/chat/app/new/editor.tsx
@@ -247,10 +247,13 @@ export default function AgentEditor({
   const editorForm = useRef<HTMLFormElement>(null);
 
   const [voices, setVoices] = useState(() => defaultVoices.slice());
-  const [features, setFeatures] = useState<FeaturesObject>({
-    tts: null,
-    rateLimit: null,
-    storeItems: null,
+  const [features, setFeatures] = useState<FeaturesObject>(() => {
+    const savedFeatures = localStorage.getItem('features');
+    return savedFeatures ? JSON.parse(savedFeatures) : {
+      tts: null,
+      rateLimit: null,
+      storeItems: null,
+    };
   });
   const [sourceCode, setSourceCode] = useState(() => makeAgentSourceCode(features));
 
@@ -301,6 +304,10 @@ export default function AgentEditor({
       localStorage.removeItem('homespaceBlob');
     }
   }, [homespaceBlob]);
+
+  useEffect(() => {
+    localStorage.setItem('features', JSON.stringify(features));
+  }, [features]);
 
   // useEffect(() => {
   //   (async () => {

--- a/apps/chat/app/new/editor.tsx
+++ b/apps/chat/app/new/editor.tsx
@@ -204,6 +204,18 @@ type AgentEditorProps = {
   user: any;
 };
 
+const clearLocalStorage = () => {
+  localStorage.removeItem('name');
+  localStorage.removeItem('bio');
+  localStorage.removeItem('visualDescription');
+  localStorage.removeItem('homespaceDescription');
+  localStorage.removeItem('previewUrl');
+  localStorage.removeItem('homespaceUrl');
+  localStorage.removeItem('previewBlob');
+  localStorage.removeItem('homespaceBlob');
+  localStorage.removeItem('features');
+};
+
 export default function AgentEditor({
   user,
 }: AgentEditorProps) {
@@ -853,6 +865,7 @@ export default function AgentEditor({
                   const agentJsonOutput = JSON.parse(agentJsonOutputString);
                   const guid = agentJsonOutput.id;
                   location.href = `/agents/${guid}`;
+                  clearLocalStorage();
                 } else {
                   console.error('failed to deploy agent', res);
                 }

--- a/apps/chat/app/new/editor.tsx
+++ b/apps/chat/app/new/editor.tsx
@@ -719,6 +719,28 @@ export default function AgentEditor({
     },
   });
 
+  const handleClear = (e: any) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    clearLocalStorage();
+    setName('');
+    setBio('');
+    setVisualDescription('');
+    setHomespaceDescription('');
+    setPreviewBlob(null);
+    setPreviewUrl('');
+    setHomespaceBlob(null);
+    setHomespaceUrl('');
+    setFeatures({
+      tts: null,
+      rateLimit: null,
+      storeItems: null,
+    });
+    setSourceCode('');
+    setBuilderMessages([]);
+  }
+
   // render
   return (
     <div className="flex flex-1">
@@ -995,6 +1017,7 @@ export default function AgentEditor({
               }}
               disabled={deploying}
             >{!deploying ? `Deploy` : 'Deploying...'}</Button>
+            <Button onClick={handleClear} disabled={deploying}>Clear</Button>
           </div>
         </div>
         <div className="flex flex-col">

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/base64.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/base64.mjs
@@ -24,3 +24,23 @@ export const blobToDataUrl = async (blob) => {
 	const arrayBuffer = await blob.arrayBuffer();
   return arrayBufferToDataUrl(arrayBuffer, blob.type);
 }
+
+export const blobToBase64 = (blob) => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+};
+
+export const base64ToBlob = (base64) => {
+  const byteString = atob(base64.split(',')[1]);
+  const mimeString = base64.split(',')[0].split(':')[1].split(';')[0];
+  const ab = new ArrayBuffer(byteString.length);
+  const ia = new Uint8Array(ab);
+  for (let i = 0; i < byteString.length; i++) {
+    ia[i] = byteString.charCodeAt(i);
+  }
+  return new Blob([ab], { type: mimeString });
+};


### PR DESCRIPTION
This PR persists the data generated on the /new page for the agent creation process.
Currently any navigation or a refresh wipes out the data generated for a user (which used credits to generate so it really isnt good).

The implementation uses localStorage k-v to save the progress made, and load the saved data on state initialisation.

This currently does not support multiple session/agent creation flows (if a user wants to create different agents but has not completed a few or any).

Adds a "Clear" button which removes data persisted for the agent from the local storage and the page state