### PR TITLE
fix arrow icon to appear on non-hovered button state

### DIFF
--- a/apps/chat/components/ui/icons.tsx
+++ b/apps/chat/components/ui/icons.tsx
@@ -256,7 +256,7 @@ function IconArrowDown({ className, ...props }: React.ComponentProps<'svg'>) {
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 256 256"
       fill="currentColor"
-      className={cn('size-4', className)}
+      className={cn('size-4', className, 'text-white')}
       {...props}
     >
       <path d="m205.66 149.66-72 72a8 8 0 0 1-11.32 0l-72-72a8 8 0 0 1 11.32-11.32L120 196.69V40a8 8 0 0 1 16 0v156.69l58.34-58.35a8 8 0 0 1 11.32 11.32Z" />


### PR DESCRIPTION
Make arrow down icon in the scroll to bottom button appear always (currently only appears when the button was hovered, making the button appear completely dark)