### PR TITLE
Node version check

### DIFF
--- a/.github/workflows/usdk-test.yml
+++ b/.github/workflows/usdk-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '20' # Specify the Node.js version you are using
+        node-version: '22' # Specify the Node.js version you are using
 
     - name: Install dependencies
       run: cd packages/usdk && npm install --no-optional

--- a/packages/usdk/cli.js
+++ b/packages/usdk/cli.js
@@ -1,3 +1,6 @@
+import { checkNodeVersion, currentSdkVersion, latestSdkVersion } from './lib/version.mjs';
+checkNodeVersion();
+
 import path from 'path';
 import stream from 'stream';
 import fs from 'fs';
@@ -72,7 +75,7 @@ import {
   loginLocation,
 } from './lib/locations.mjs';
 import {
-  version,
+  // version,
   login,
   logout,
   status,
@@ -100,7 +103,6 @@ import {
   generateMnemonic,
 } from './util/ethereum-utils.mjs';
 import LoggerFactory from './util/logger/logger-factory.mjs';
-import { getLatestVersion } from './lib/version.mjs';
 
 globalThis.WebSocket = WebSocket; // polyfill for multiplayer library
 
@@ -1384,8 +1386,8 @@ const handleError = async (fn) => {
 export const main = async () => {
   try {
 
-    const ver = version();
-    const latestVersion = getLatestVersion();
+    const ver = currentSdkVersion();
+    const latestVersion = latestSdkVersion();
 
     const isLatestVersion = latestVersion === ver;
 

--- a/packages/usdk/lib/commands.mjs
+++ b/packages/usdk/lib/commands.mjs
@@ -1,5 +1,5 @@
 export {
-  version,
+  currentSdkVersion,
 } from './version.mjs';
 export {
   login,

--- a/packages/usdk/lib/commands.mjs
+++ b/packages/usdk/lib/commands.mjs
@@ -1,5 +1,5 @@
 export {
-  currentSdkVersion,
+  currentSdkVersion as version,
 } from './version.mjs';
 export {
   login,

--- a/packages/usdk/lib/version.mjs
+++ b/packages/usdk/lib/version.mjs
@@ -2,6 +2,8 @@ import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import pc from 'picocolors';
 
+// Importing package.json using readFileSync and JSON.parse to ensure compatibility across different Node.js versions.
+// Direct import with 'assert { type: "json" }' can cause syntax errors in older Node.js versions.
 const packageJsonPath = './package.json';
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 

--- a/packages/usdk/lib/version.mjs
+++ b/packages/usdk/lib/version.mjs
@@ -1,16 +1,40 @@
 import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
 import pc from 'picocolors';
-import packageJson from '../package.json' with { type: 'json' };
 
-// Get the current version
-export const version = () => packageJson.version;
-// Get the latest version
-export function getLatestVersion() {
+const packageJsonPath = './package.json';
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+
+// Get the current version of the sdk
+export const currentSdkVersion = () => packageJson.version;
+
+// Get the latest version of the sdk
+export function latestSdkVersion() {
   try {
     const latestVersion = execSync(`npm show ${packageJson.name} version`).toString().trim();
     return latestVersion;
   } catch (error) {
-   // console.log(pc.red('Error checking version. '), error.message);
     console.log(pc.red('Error checking latest usdk version on the registry.'));
   }
 }
+
+// Check if the Node.js version is equal or above the minimum required version
+export function checkNodeVersion(packageJsonPath = './package.json') {
+  const { engines } = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) || {};
+  const requiredVersion = engines?.node;
+
+  if (!requiredVersion) {
+    console.error('Node.js version requirement is not defined in package.json.');
+    process.exit(1);
+  }
+
+  const currentMajor = +process.version.slice(1).split('.')[0];
+  const requiredMajor = +requiredVersion.match(/\d+/)[0];
+
+  if (currentMajor < requiredMajor) {
+    console.error(`Node.js ${requiredVersion} or higher is required. You are using ${process.version}.`);
+    process.exit(1);
+  }
+}
+
+

--- a/packages/usdk/lib/version.mjs
+++ b/packages/usdk/lib/version.mjs
@@ -21,18 +21,18 @@ export function latestSdkVersion() {
 // Check if the Node.js version is equal or above the minimum required version
 export function checkNodeVersion(packageJsonPath = './package.json') {
   const { engines } = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) || {};
-  const requiredNodeVersion = engines?.node;
+  const requiredVersion = engines?.node;
 
-  if (!requiredNodeVersion) {
-    console.log(pc.red('Node.js version requirement is not defined in package.json.'));
+  if (!requiredVersion) {
+    console.error(pc.red('Node.js version requirement is not defined in package.json.'));
     process.exit(1);
   }
 
-  const currentVersion = process.version.match(/\d+\.\d+\.\d+/)[0];
-  const requiredVersion = requiredNodeVersion.match(/\d+\.\d+\.\d+/)[0];
+  const currentMajor = +process.version.slice(1).split('.')[0];
+  const requiredMajor = +requiredVersion.match(/\d+/)[0];
 
-  if (currentVersion < requiredVersion) {
-    console.log(pc.yellow(`Node.js v${requiredVersion} or higher is required. You are using v${currentVersion}.`));
+  if (currentMajor < requiredMajor) {
+    console.error(pc.yellow(`Node.js ${requiredVersion} or higher is required. You are using ${process.version}.`));
     process.exit(1);
   }
 }

--- a/packages/usdk/lib/version.mjs
+++ b/packages/usdk/lib/version.mjs
@@ -21,18 +21,18 @@ export function latestSdkVersion() {
 // Check if the Node.js version is equal or above the minimum required version
 export function checkNodeVersion(packageJsonPath = './package.json') {
   const { engines } = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) || {};
-  const requiredVersion = engines?.node;
+  const requiredNodeVersion = engines?.node;
 
-  if (!requiredVersion) {
-    console.error('Node.js version requirement is not defined in package.json.');
+  if (!requiredNodeVersion) {
+    console.log(pc.red('Node.js version requirement is not defined in package.json.'));
     process.exit(1);
   }
 
-  const currentMajor = +process.version.slice(1).split('.')[0];
-  const requiredMajor = +requiredVersion.match(/\d+/)[0];
+  const currentVersion = process.version.match(/\d+\.\d+\.\d+/)[0];
+  const requiredVersion = requiredNodeVersion.match(/\d+\.\d+\.\d+/)[0];
 
-  if (currentMajor < requiredMajor) {
-    console.error(`Node.js ${requiredVersion} or higher is required. You are using ${process.version}.`);
+  if (currentVersion < requiredVersion) {
+    console.log(pc.yellow(`Node.js v${requiredVersion} or higher is required. You are using v${currentVersion}.`));
     process.exit(1);
   }
 }


### PR DESCRIPTION
Add Node.js version check and SDK version comparison

- Implemented `checkNodeVersion` function in `version.mjs` to ensure the current Node.js version meets the minimum requirement specified in `package.json`.
- Added `currentSdkVersion` and `latestSdkVersion` functions to retrieve the current and latest SDK versions.
- Integrated `checkNodeVersion` into `cli.js` to enforce Node.js version checks at runtime.

SOT for min required node check: package.json -> engines -> node