### PR TITLE
Agent version update log

### DIFF
--- a/packages/usdk/lib/chat.mjs
+++ b/packages/usdk/lib/chat.mjs
@@ -7,12 +7,20 @@ import {
   join,
   leave,
 } from '../util/connect-utils.mjs';
+import { warnIfAgentsUseNewerSDKVersion } from './version.mjs';
 
 //
 
 export const chat = async (args, opts) => {
   // console.log('got chat args', args);
   const agentSpecs = await parseAgentSpecs(args._[0]);
+
+  try {
+    await warnIfAgentsUseNewerSDKVersion(agentSpecs, opts);
+  } catch (error) {
+    // do nothing
+  }
+
   const room = args.room;
   const browser = args.browser;
   const runtime = args.runtime ?? 'node';

--- a/packages/usdk/lib/version.mjs
+++ b/packages/usdk/lib/version.mjs
@@ -38,9 +38,9 @@ export async function warnIfAgentsUseNewerSDKVersion(agentSpecs, opts) {
   for (const {guid, version} of agentVersionResults) {
     if (version && version > ver) {
       console.warn(pc.yellow(
-        `Warning: Agent ${guid} was created using SDK version ${version}, but you are using SDK version ${ver}. ` +
-        `Agent behavior may differ due to version mismatch. Please update your USDK version using 'npm install -g @upstreet/usdk@latest'`
-      ));
+        `Warning: Agent ${guid} was created with SDK version ${version}, but you're currently using SDK version ${ver}. ` +
+        `This version mismatch may cause unexpected behavior. Please update your USDK to the latest version using 'npm install usdk -g'.`
+      ));      
     }
   }
 }

--- a/packages/usdk/lib/version.mjs
+++ b/packages/usdk/lib/version.mjs
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
 import pc from 'picocolors';
 import packageJson from '../package.json' with { type: 'json' };
+import { makeAnonymousClient } from '../packages/upstreet-agent/packages/react-agents/util/supabase-client.mjs';
 
 // Get the current version
 export const version = () => packageJson.version;
@@ -14,3 +15,74 @@ export function getLatestVersion() {
     console.log(pc.red('Error checking latest usdk version on the registry.'));
   }
 }
+
+export const isLatestSDKVersion = () => {
+  const ver = version();
+  const latestVersion = getLatestVersion();
+  return latestVersion === ver;
+};
+
+
+export async function warnIfAgentsUseNewerSDKVersion(agentSpecs, opts) {
+  const ver = version();
+  
+  // get agent versions in parallel
+  const agentVersionResults = await Promise.all(
+    agentSpecs.map(agentSpec => 
+      getAgentVersion(agentSpec, opts.jwt)
+        .then(version => ({guid: agentSpec.guid, version}))
+    )
+  );
+  
+  // check versions and warn about mismatches
+  for (const {guid, version} of agentVersionResults) {
+    if (version && version > ver) {
+      console.warn(pc.yellow(
+        `Warning: Agent ${guid} was created using SDK version ${version}, but you are using SDK version ${ver}. ` +
+        `Agent behavior may differ due to version mismatch. Please update your USDK version using 'npm install -g @upstreet/usdk@latest'`
+      ));
+    }
+  }
+}
+
+
+const getAgentVersionFromGuid = async (guid, jwt) => {
+  const supabase = makeAnonymousClient(jwt);
+  const { data, error } = await supabase
+    .from('assets')
+    .select('version')
+    .eq('id', guid);
+  return data?.[0]?.version;
+};
+
+const getAgentVersionFromPath = async (p) => {
+  const makeEnoent = () => new Error('not an agent directory: ' + p);
+
+  const wranglerTomlPath = path.join(p, 'wrangler.toml');
+  try {
+    const wranglerTomString = await fs.promises.readFile(wranglerTomlPath, 'utf8');
+    const wranglerToml = toml.parse(wranglerTomString);
+    const agentJsonString = wranglerToml.vars.AGENT_JSON;
+    const agentJson = agentJsonString && JSON.parse(agentJsonString);
+    const version = agentJson?.version;
+    if (version) {
+      return version;
+    } else {
+      throw makeEnoent();
+    }
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw makeEnoent();
+    } else {
+      throw err;
+    }
+  }
+};
+
+export const getAgentVersion = async (args, jwt) => {
+  if (args.directory) {
+    return await getAgentVersionFromPath(args.directory, jwt);
+  } else {
+    return await getAgentVersionFromGuid(args.guid, jwt);
+  }
+};


### PR DESCRIPTION
This PR adds Agent version comparison with the current USDK version installed on the user's workstation.

Agent's created after a breaking change update to USDK would not work/cause unexpected behaviour with user's on a lower USDK version hence they need to be warned.
