### PR TITLE
Add additional logs on create process updates

### DIFF
--- a/packages/usdk/lib/create.mjs
+++ b/packages/usdk/lib/create.mjs
@@ -366,15 +366,18 @@ export const create = async (args, opts) => {
 
   // remove old directory
   const _prepareDirectory = async () => {
+    console.log(pc.italic('Preparing directory...'));
     await cleanDir(dstDir, {
       force,
       forceNoConfirm,
     });
     // bootstrap destination directory
     await mkdirp(dstDir);
+    console.log(pc.italic('Directory prepared...'));
   };
   await _prepareDirectory();
 
+  console.log(pc.italic('Generating Agent...'));
   // generate the agent
   let agentJson = makeAgentJsonInit({
     agentJsonString,
@@ -395,12 +398,10 @@ export const create = async (args, opts) => {
       jwt,
     });
   }
-  else {
-    console.log(pc.italic('Generating agent...'));
-  }
+ 
   agentJson = updateAgentJsonAuth(agentJson, agentAuthSpec);
   agentJson = ensureAgentJsonDefaults(agentJson);
-  console.log(pc.italic('Agent generated.'));
+  console.log(pc.italic('Agent generated...'));
   console.log(pc.green('Name:'), agentJson.name);
   console.log(pc.green('Bio:'), agentJson.bio);
   console.log(pc.green('Description:'), agentJson.description);

--- a/packages/usdk/lib/directory-util.mjs
+++ b/packages/usdk/lib/directory-util.mjs
@@ -35,10 +35,11 @@ export const cleanDir = async (dstDir, { force, forceNoConfirm } = {}) => {
       }
 
       // Remove all files.
-      console.log(pc.italic('\nRemoving old files...'));
+      console.log(pc.italic('Removing old files...'));
       await Promise.all(
         files.map((filePath) => rimraf(path.join(dstDir, filePath))),
       );
+      console.log(pc.italic('Removed old files...'));
     } else {
       // throw error
       throw new Error('directory is not empty (-f to override)');


### PR DESCRIPTION
This PR only adds additional logs to the agent creation process for more frequent state update logs improving DX and to let users know accurately of the current creation steps being completed.

Previously users reported not being aware of where the installation process was when provided additional flags such as the prompt argument (-p "...")
