### PR TITLE
Fix player spec not found fe

### DIFF
--- a/apps/chat/components/ui/multiplayer-actions.tsx
+++ b/apps/chat/components/ui/multiplayer-actions.tsx
@@ -360,8 +360,8 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
               refresh();
             });
             multiplayerConnection.addEventListener('leave', (e: any) => {
-              const { player } = e.data;
-              const profile = player.getPlayerSpec();
+              const { remotePlayer } = e.data;
+              const profile = remotePlayer.getPlayerSpec();
               const { id: userId, name } = profile;
               const leaveMessage = {
                 method: 'leave',

--- a/apps/chat/components/ui/multiplayer-actions.tsx
+++ b/apps/chat/components/ui/multiplayer-actions.tsx
@@ -342,10 +342,8 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
 
             // join + leave messages
             multiplayerConnection.addEventListener('join', (e: any) => {
-              console.log('got join', e.data);
               const { remotePlayer } = e.data;
 
-              console.log('got join 2', remotePlayer);
               const profile = remotePlayer.getPlayerSpec();
               const { id: userId, name } = profile;
               const joinMessage = {

--- a/apps/chat/components/ui/multiplayer-actions.tsx
+++ b/apps/chat/components/ui/multiplayer-actions.tsx
@@ -342,8 +342,8 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
 
             // join + leave messages
             multiplayerConnection.addEventListener('join', (e: any) => {
-              const { remotePlayer } = e.data;
-              const profile = remotePlayer.getPlayerSpec();
+              const { player } = e.data;
+              const profile = player.getPlayerSpec();
               const { id: userId, name } = profile;
               const joinMessage = {
                 method: 'join',
@@ -357,8 +357,8 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
               refresh();
             });
             multiplayerConnection.addEventListener('leave', (e: any) => {
-              const { remotePlayer } = e.data;
-              const profile = remotePlayer.getPlayerSpec();
+              const { player } = e.data;
+              const profile = player.getPlayerSpec();
               const { id: userId, name } = profile;
               const leaveMessage = {
                 method: 'leave',

--- a/apps/chat/components/ui/multiplayer-actions.tsx
+++ b/apps/chat/components/ui/multiplayer-actions.tsx
@@ -343,7 +343,6 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
             // join + leave messages
             multiplayerConnection.addEventListener('join', (e: any) => {
               const { remotePlayer } = e.data;
-
               const profile = remotePlayer.getPlayerSpec();
               const { id: userId, name } = profile;
               const joinMessage = {

--- a/apps/chat/components/ui/multiplayer-actions.tsx
+++ b/apps/chat/components/ui/multiplayer-actions.tsx
@@ -342,8 +342,11 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
 
             // join + leave messages
             multiplayerConnection.addEventListener('join', (e: any) => {
-              const { player } = e.data;
-              const profile = player.getPlayerSpec();
+              console.log('got join', e.data);
+              const { remotePlayer } = e.data;
+
+              console.log('got join 2', remotePlayer);
+              const profile = remotePlayer.getPlayerSpec();
               const { id: userId, name } = profile;
               const joinMessage = {
                 method: 'join',

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -183,24 +183,20 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
               playersMap.add(playerId, remotePlayer);
             }
             // Dispatch join event when playerSpec is updated
-            const joinMessage = {
-              ...e.data,
-              remotePlayer,
-            };
             this.dispatchEvent(new MessageEvent('join', {
-              data: joinMessage,
+              data: {
+                remotePlayer,
+              },
             }));
           }
         });
 
         // Dispatch join event initially if playerSpec is already set
         if (remotePlayer.getPlayerSpec()) {
-          const joinMessage = {
-            ...e.data,
-            remotePlayer,
-          };
           this.dispatchEvent(new MessageEvent('join', {
-            data: joinMessage,
+            data: {
+              remotePlayer
+            },
           }));
         }
       });
@@ -222,13 +218,10 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
           throw new Error('remote player not found');
         }
 
-        const leaveMessage = {
-          ...e.data,
-          remotePlayer,
-        };
-
         this.dispatchEvent(new MessageEvent('leave', {
-          data: leaveMessage,
+          data: {
+            remotePlayer,
+          },
         }));
       });
       // map multimedia events virtualPlayers -> playersMap

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -158,8 +158,6 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
       virtualPlayers.addEventListener('join', (e) => {
         const { playerId, player } = e.data;
 
-        console.log('got join 3', e.data);
-
         const playerSpec = player.getKeyValue('playerSpec');
         if (connected) {
           // this.log('react agents client: remote player joined:', playerId);

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -212,8 +212,13 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
           throw new Error('remote player not found');
         }
 
+        const leaveMessage = {
+          ...e.data,
+          remotePlayer,
+        };
+
         this.dispatchEvent(new MessageEvent('leave', {
-          data: e.data,
+          data: leaveMessage,
         }));
       });
       // map multimedia events virtualPlayers -> playersMap

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -195,7 +195,7 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
         if (remotePlayer.getPlayerSpec()) {
           this.dispatchEvent(new MessageEvent('join', {
             data: {
-              remotePlayer
+              player: remotePlayer,
             },
           }));
         }
@@ -220,7 +220,7 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
 
         this.dispatchEvent(new MessageEvent('leave', {
           data: {
-            remotePlayer,
+            player: remotePlayer,
           },
         }));
       });

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -157,6 +157,7 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
     const _trackRemotePlayers = () => {
       virtualPlayers.addEventListener('join', (e) => {
         const { playerId, player } = e.data;
+
         const playerSpec = player.getKeyValue('playerSpec');
         if (connected) {
           // this.log('react agents client: remote player joined:', playerId);
@@ -184,8 +185,13 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
           }
         });
 
+        const joinMessage = {
+          ...e.data,
+          remotePlayer,
+        };
+        
         this.dispatchEvent(new MessageEvent('join', {
-          data: e.data,
+          data: joinMessage,
         }));
       });
       virtualPlayers.addEventListener('leave', e => {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -158,6 +158,8 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
       virtualPlayers.addEventListener('join', (e) => {
         const { playerId, player } = e.data;
 
+        console.log('got join 3', e.data);
+
         const playerSpec = player.getKeyValue('playerSpec');
         if (connected) {
           // this.log('react agents client: remote player joined:', playerId);
@@ -182,17 +184,27 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
             if (!playersMap.has(playerId)) {
               playersMap.add(playerId, remotePlayer);
             }
+            // Dispatch join event when playerSpec is updated
+            const joinMessage = {
+              ...e.data,
+              remotePlayer,
+            };
+            this.dispatchEvent(new MessageEvent('join', {
+              data: joinMessage,
+            }));
           }
         });
 
-        const joinMessage = {
-          ...e.data,
-          remotePlayer,
-        };
-        
-        this.dispatchEvent(new MessageEvent('join', {
-          data: joinMessage,
-        }));
+        // Dispatch join event initially if playerSpec is already set
+        if (remotePlayer.getPlayerSpec()) {
+          const joinMessage = {
+            ...e.data,
+            remotePlayer,
+          };
+          this.dispatchEvent(new MessageEvent('join', {
+            data: joinMessage,
+          }));
+        }
       });
       virtualPlayers.addEventListener('leave', e => {
         const { playerId } = e.data;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -182,23 +182,14 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
             if (!playersMap.has(playerId)) {
               playersMap.add(playerId, remotePlayer);
             }
-            // Dispatch join event when playerSpec is updated
-            this.dispatchEvent(new MessageEvent('join', {
-              data: {
-                remotePlayer,
-              },
-            }));
           }
         });
 
-        // Dispatch join event initially if playerSpec is already set
-        if (remotePlayer.getPlayerSpec()) {
-          this.dispatchEvent(new MessageEvent('join', {
-            data: {
-              player: remotePlayer,
-            },
-          }));
-        }
+        this.dispatchEvent(new MessageEvent('join', {
+          data: {
+            player: remotePlayer,
+          },
+        }));
       });
       virtualPlayers.addEventListener('leave', e => {
         const { playerId } = e.data;


### PR DESCRIPTION
- This PR fixes the player.getPlayerSpec() is not a function issue.
- event data set to remotePlayer only since that is being extracted and used in codebase

VirtualPlayer inside e.data does not have the getPlayerSpec() function and is defined on the Player object