### PR TITLE
Fix PlayerSpec missing when agent joins

### DIFF
--- a/apps/chat/components/ui/multiplayer-actions.tsx
+++ b/apps/chat/components/ui/multiplayer-actions.tsx
@@ -340,6 +340,26 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
             playersMap = multiplayerConnection.playersMap;
             typingMap = multiplayerConnection.typingMap;
 
+
+            // join event when the playerSpec is updated and the player is not already in the playersMap
+            // this is to be listened to for the case where the playerSpec is set after the player is connected
+            multiplayerConnection.addEventListener('playerSpecUpdate', (e: any) => {
+              const { player } = e.data;
+              const profile = player.getPlayerSpec();
+              const { id: userId, name } = profile;
+
+              if (!playersMap.has(userId)) {
+                const joinMessage = {
+                  method: 'join',
+                  userId,
+                  name,
+                  args: {},
+                  timestamp: Date.now(),
+                };
+                messages = [...messages, joinMessage];
+              }
+              refresh();
+            });
             // join + leave messages
             multiplayerConnection.addEventListener('join', (e: any) => {
               const { player } = e.data;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -157,6 +157,7 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
     const _trackRemotePlayers = () => {
       virtualPlayers.addEventListener('join', (e) => {
         const { playerId, player } = e.data;
+
         const playerSpec = player.getKeyValue('playerSpec');
         if (connected) {
           // this.log('react agents client: remote player joined:', playerId);
@@ -180,13 +181,21 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
             remotePlayer.setPlayerSpec(val);
             if (!playersMap.has(playerId)) {
               playersMap.add(playerId, remotePlayer);
+
+              // dispatch join event when the playerSpec is updated and the player is not already in the playersMap
+              this.dispatchEvent(new MessageEvent('join', {
+                data: e.data,
+              }));
             }
           }
         });
 
-        this.dispatchEvent(new MessageEvent('join', {
-          data: e.data,
-        }));
+        // dispatch join event if the playerSpec is already set
+        if (remotePlayer.getPlayerSpec()) {
+          this.dispatchEvent(new MessageEvent('join', {
+            data: e.data,
+          }));
+        }
       });
       virtualPlayers.addEventListener('leave', e => {
         const { playerId } = e.data;
@@ -207,7 +216,9 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
         }
 
         this.dispatchEvent(new MessageEvent('leave', {
-          data: e.data,
+          data: {
+            player: remotePlayer,
+          },
         }));
       });
       // map multimedia events virtualPlayers -> playersMap

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -184,7 +184,7 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
 
               // dispatch join event when the playerSpec is updated and the player is not already in the playersMap
               this.dispatchEvent(new MessageEvent('playerSpecUpdate', {
-                data: e.data,
+                player: remotePlayer,
               }));
             }
           }

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -216,9 +216,7 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
         }
 
         this.dispatchEvent(new MessageEvent('leave', {
-          data: {
-            player: remotePlayer,
-          },
+          data: e.data,
         }));
       });
       // map multimedia events virtualPlayers -> playersMap

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -183,7 +183,7 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
               playersMap.add(playerId, remotePlayer);
 
               // dispatch join event when the playerSpec is updated and the player is not already in the playersMap
-              this.dispatchEvent(new MessageEvent('join', {
+              this.dispatchEvent(new MessageEvent('playerSpecUpdate', {
                 data: e.data,
               }));
             }


### PR DESCRIPTION
This PR handles the case where the agent joining the room has playerSpec data initialised.

- adds a playerSpecUpdate event to the react-agents-client and a listener for the event in the multiplayer actions

![image](https://github.com/user-attachments/assets/f6a182ce-b88e-4152-ae19-1076ef47c268)
