### PR TITLE
useEnv hook

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/agent-renderer.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/agent-renderer.tsx
@@ -180,6 +180,9 @@ export class AgentRenderer {
       const agentJson = JSON.parse(agentJsonString);
       return agentJson;
     };
+    const useEnv = () => {
+      return this.auth;
+    }
     const useEnvironment = () => {
       return this.env.WORKER_ENV as string;
     };
@@ -211,6 +214,7 @@ export class AgentRenderer {
     this.appContextValue = new AppContextValue({
       subtleAi,
       agentJson: useAgentJson(),
+      env: useEnv(),
       environment: useEnvironment(),
       wallets: useWallets(),
       authToken: useAuthToken(),

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/app-context-value.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/app-context-value.ts
@@ -29,6 +29,7 @@ import { useAgent } from '../hooks';
 export class AppContextValue {
   subtleAi: SubtleAi;
   agentJson: object;
+  env: object;
   environment: string;
   wallets: any;
   authToken: string;
@@ -41,6 +42,7 @@ export class AppContextValue {
   constructor({
     subtleAi,
     agentJson,
+    env,
     environment,
     wallets,
     authToken,
@@ -53,6 +55,7 @@ export class AppContextValue {
     subtleAi: SubtleAi;
     agentJson: object;
     environment: string;
+    env: object;
     wallets: any;
     authToken: string;
     supabase: any;
@@ -63,6 +66,7 @@ export class AppContextValue {
   }) {
     this.subtleAi = subtleAi;
     this.agentJson = agentJson;
+    this.env = env;
     this.environment = environment;
     this.wallets = wallets;
     this.authToken = authToken;
@@ -77,6 +81,9 @@ export class AppContextValue {
 
   useAgentJson() {
     return this.agentJson;
+  }
+  useEnv() {
+    return this.env;
   }
   useEnvironment() {
     return this.environment;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/hooks.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/hooks.ts
@@ -44,14 +44,21 @@ import {
 
 //
 
+// get the .env.txt content (parsed as an object)
+// note: this contains keys and must not be exposed to the user (such as by including it in prompts)
 export const useEnv: () => string = () => {
   const appContextValue = useContext(AppContext);
   return appContextValue.useEnv();
 };
+// get the 'development' or 'production' environment variable
+// not to be confused with useEnv()
 export const useEnvironment: () => string = () => {
   const appContextValue = useContext(AppContext);
   return appContextValue.useEnvironment();
 };
+// get the agent's authentication token
+// note: this contains keys and must not be exposed to the user (such as by including it in prompts)
+// not to be confused with useEnv()
 export const useAuthToken: () => string = () => {
   const appContextValue = useContext(AppContext);
   return appContextValue.useAuthToken();

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/hooks.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/hooks.ts
@@ -44,6 +44,10 @@ import {
 
 //
 
+export const useEnv: () => string = () => {
+  const appContextValue = useContext(AppContext);
+  return appContextValue.useEnv();
+};
 export const useEnvironment: () => string = () => {
   const appContextValue = useContext(AppContext);
   return appContextValue.useEnvironment();

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/types/agents.d.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/types/agents.d.ts
@@ -709,6 +709,7 @@ export type AppContextValue = {
   subtleAi: SubtleAi;
 
   useAgentJson: () => object;
+  useEnv: () => string;
   useEnvironment: () => string;
   useWallets: () => object[];
   useAuthToken: () => string;


### PR DESCRIPTION
Adds useEnv hook to access the `.env.txt` contents (parsed as an object).

Not to be confused with `useEnvironment()`, which is the `'development'` vs `'production'` string. Might be a bad name.