### PR TITLE
revert join and leave message event data

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -181,25 +181,13 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
             remotePlayer.setPlayerSpec(val);
             if (!playersMap.has(playerId)) {
               playersMap.add(playerId, remotePlayer);
-
-              // dispatch join event when the playerSpec is updated and the player is not already in the playersMap
-              this.dispatchEvent(new MessageEvent('playerSpecUpdate', {
-                data: {
-                  player: remotePlayer,
-                },
-              }));
             }
           }
         });
 
-        // dispatch join event if the playerSpec is already set
-        if (remotePlayer.getPlayerSpec()) {
-          this.dispatchEvent(new MessageEvent('join', {
-            data: {
-              player: remotePlayer,
-            },
-          }));
-        }
+        this.dispatchEvent(new MessageEvent('join', {
+          data: e.data,
+        }));
       });
       virtualPlayers.addEventListener('leave', e => {
         const { playerId } = e.data;
@@ -220,9 +208,7 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
         }
 
         this.dispatchEvent(new MessageEvent('leave', {
-          data: {
-            player: remotePlayer,
-          },
+          data: e.data,
         }));
       });
       // map multimedia events virtualPlayers -> playersMap


### PR DESCRIPTION
This PR reverts the previously added 'join' and 'leave' event dispatch data updates.