### PR TITLE
Add Agent run command starting the agent runtime

### DIFF
--- a/packages/usdk/cli.js
+++ b/packages/usdk/cli.js
@@ -84,6 +84,7 @@ import {
   update,
   authenticate,
   chat,
+  runAgent,
 } from './lib/commands.mjs';
 import {
   makeRoomName,
@@ -1522,6 +1523,26 @@ export const main = async () => {
           const jwt = await getLoginJwt();
 
           await pull(args, {
+            jwt,
+          });
+        });
+      });
+    program
+      .command('run')
+      .description('Run an agent')
+      .argument('[agentDirs...]', 'Directory of the agent(s)')
+      .action(async (agentDirs = [], opts = {}) => {
+        await handleError(async () => {
+          commandExecuted = true;
+          let args;
+          args = {
+            _: [agentDirs],
+            ...opts,
+          };
+
+          const jwt = await getLoginJwt();
+
+          await runAgent(args, {
             jwt,
           });
         });

--- a/packages/usdk/lib/commands.mjs
+++ b/packages/usdk/lib/commands.mjs
@@ -14,6 +14,9 @@ export {
   pull,
 } from './create.mjs';
 export {
+  runAgent,
+} from './run-agent.mjs';
+export {
   deploy,
 } from './deploy.mjs';
 export {

--- a/packages/usdk/lib/run-agent.mjs
+++ b/packages/usdk/lib/run-agent.mjs
@@ -1,0 +1,38 @@
+import { ReactAgentsNodeRuntime } from '../packages/upstreet-agent/packages/react-agents-node/node-runtime.mjs';
+import { ReactAgentsWranglerRuntime } from '../packages/upstreet-agent/packages/react-agents-wrangler/wrangler-runtime.mjs';
+import { parseAgentSpecs } from './agent-spec-utils.mjs';
+
+export const runAgent = async (args, opts) => {
+  console.log('runAgent', args, opts);
+  const agentSpecs = await parseAgentSpecs(args._[0]);
+  const runtime = args.runtime ?? 'node';
+  const debug = !!args.debug;
+  // opts
+  const jwt = opts.jwt;
+  if (!jwt) {
+    throw new Error('You must be logged in to chat.');
+  }
+
+  // start dev servers for the agents
+  const Runtime = (() => {
+    if (runtime === 'node') {
+      return ReactAgentsNodeRuntime;
+    } else if (runtime === 'wrangler') {
+      return ReactAgentsWranglerRuntime;
+    } else {
+      throw new Error('unknown runtime: ' + runtime);
+    }
+  })();
+  const startPromises = agentSpecs.map(async (agentSpec) => {
+    if (agentSpec.directory) {
+      const runtime = new Runtime(agentSpec);
+      await runtime.start({
+        debug,
+      });
+    }
+  });
+  await Promise.all(startPromises);
+
+  console.log('started agents');
+  return;
+};


### PR DESCRIPTION
Adds usdk run command which spins up the agent runtime.
Intended for use cases where user's want a live local agent but not necessarily to be in a chat 