### PR TITLE
Sync Player addition with PlayerSpec

### DIFF
--- a/apps/chat/components/ui/multiplayer-actions.tsx
+++ b/apps/chat/components/ui/multiplayer-actions.tsx
@@ -347,8 +347,9 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
               const { player } = e.data;
               const profile = player.getPlayerSpec();
               const { id: userId, name } = profile;
-
               if (!playersMap.has(userId)) {
+                // add the player to the playersMap when the playerSpec is updated and the player is not already in the playersMap
+                playersMap.add(userId, player);
                 const joinMessage = {
                   method: 'join',
                   userId,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -192,7 +192,6 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
 
         // Do not add the player or dispatch join event until it has the playerSpec set
         if (remotePlayer.getPlayerSpec()) {
-          playersMap.add(playerId, remotePlayer);
           this.dispatchEvent(new MessageEvent('join', {
             data: {
               player: remotePlayer,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -180,8 +180,6 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
           if (key === 'playerSpec') {
             remotePlayer.setPlayerSpec(val);
             if (!playersMap.has(playerId)) {
-              playersMap.add(playerId, remotePlayer);
-
               // dispatch join event when the playerSpec is updated and the player is not already in the playersMap
               this.dispatchEvent(new MessageEvent('playerSpecUpdate', {
                 data: {
@@ -192,11 +190,15 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
           }
         });
 
+        // Do not add the player or dispatch join event until it has the playerSpec set
+        if (remotePlayer.getPlayerSpec()) {
+          playersMap.add(playerId, remotePlayer);
           this.dispatchEvent(new MessageEvent('join', {
             data: {
               player: remotePlayer,
             },
-        }));
+          }));
+        }
       });
       virtualPlayers.addEventListener('leave', e => {
         const { playerId } = e.data;


### PR DESCRIPTION
This PR improves the player addition logic by ensuring players are added to the playersMap only after their playerSpec is set.

Prevent early join events without the playerSpec initialised (causing getPlayerSpec crashes since an early join has the playerSpec undefined and needs to wait for an update event)