### PR TITLE
fix: docs build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,7 +1083,6 @@
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5106,7 +5105,7 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -6017,10 +6016,10 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.0",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -6055,12 +6054,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -9689,15 +9688,76 @@
       }
     },
     "node_modules/@shikijs/rehype": {
-      "version": "1.22.2",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-1.23.1.tgz",
+      "integrity": "sha512-PH5bpMDEc4nBP62Ci3lUqkxBWRTm8cdE+eY9er5QD50jAWQxhXcc1Aeax1AlyrASrtjTwCkI22M6N9iSn5p+bQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.22.2",
+        "@shikijs/types": "1.23.1",
         "@types/hast": "^3.0.4",
         "hast-util-to-string": "^3.0.1",
-        "shiki": "1.22.2",
+        "shiki": "1.23.1",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0"
+      }
+    },
+    "node_modules/@shikijs/rehype/node_modules/@shikijs/core": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.23.1.tgz",
+      "integrity": "sha512-NuOVgwcHgVC6jBVH5V7iblziw6iQbWWHrj5IlZI3Fqu2yx9awH7OIQkXIcsHsUmY19ckwSgUMgrqExEyP5A0TA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "1.23.1",
+        "@shikijs/engine-oniguruma": "1.23.1",
+        "@shikijs/types": "1.23.1",
+        "@shikijs/vscode-textmate": "^9.3.0",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.3"
+      }
+    },
+    "node_modules/@shikijs/rehype/node_modules/@shikijs/engine-javascript": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.23.1.tgz",
+      "integrity": "sha512-i/LdEwT5k3FVu07SiApRFwRcSJs5QM9+tod5vYCPig1Ywi8GR30zcujbxGQFJHwYD7A5BUqagi8o5KS+LEVgBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.23.1",
+        "@shikijs/vscode-textmate": "^9.3.0",
+        "oniguruma-to-es": "0.4.1"
+      }
+    },
+    "node_modules/@shikijs/rehype/node_modules/@shikijs/engine-oniguruma": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.23.1.tgz",
+      "integrity": "sha512-KQ+lgeJJ5m2ISbUZudLR1qHeH3MnSs2mjFg7bnencgs5jDVPeJ2NVDJ3N5ZHbcTsOIh0qIueyAJnwg7lg7kwXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.23.1",
+        "@shikijs/vscode-textmate": "^9.3.0"
+      }
+    },
+    "node_modules/@shikijs/rehype/node_modules/@shikijs/types": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.23.1.tgz",
+      "integrity": "sha512-98A5hGyEhzzAgQh2dAeHKrWW4HfCMeoFER2z16p5eJ+vmPeF6lZ/elEne6/UCU551F/WqkopqRsr1l2Yu6+A0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^9.3.0",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/rehype/node_modules/shiki": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.23.1.tgz",
+      "integrity": "sha512-8kxV9TH4pXgdKGxNOkrSMydn1Xf6It8lsle0fiqxf7a1149K1WGtdOu3Zb91T5r1JpvRPxqxU3C2XdZZXQnrig==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "1.23.1",
+        "@shikijs/engine-javascript": "1.23.1",
+        "@shikijs/engine-oniguruma": "1.23.1",
+        "@shikijs/types": "1.23.1",
+        "@shikijs/vscode-textmate": "^9.3.0",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/transformers": {
@@ -12549,7 +12609,7 @@
     },
     "node_modules/@swc/core": {
       "version": "1.8.0",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12589,12 +12649,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12612,7 +12672,7 @@
     },
     "node_modules/@swc/types": {
       "version": "0.1.14",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -13243,7 +13303,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.2.18",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -14540,7 +14600,6 @@
     },
     "node_modules/acorn": {
       "version": "7.4.1",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -15012,7 +15071,6 @@
     },
     "node_modules/arg": {
       "version": "5.0.2",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -16184,7 +16242,6 @@
     },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -18141,9 +18198,9 @@
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -18202,7 +18259,6 @@
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/diff": {
@@ -18236,7 +18292,6 @@
     },
     "node_modules/dlv": {
       "version": "1.1.3",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -18504,6 +18559,12 @@
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/emojis-list": {
@@ -21150,6 +21211,452 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/fumadocs-core": {
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-14.5.0.tgz",
+      "integrity": "sha512-oGZn3NptUdMN1LELUHvYoZ1B5kmC9O5aLjCv2eQNbp9pDt+BtHlFMyqdLzA1idVaOr4JWfK/MsfP2udyu0THkg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.7",
+        "@orama/orama": "^3.0.1",
+        "@shikijs/rehype": "^1.23.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-to-estree": "^3.1.0",
+        "hast-util-to-jsx-runtime": "^2.3.2",
+        "image-size": "^1.1.1",
+        "negotiator": "^1.0.0",
+        "react-remove-scroll": "^2.6.0",
+        "remark": "^15.0.0",
+        "remark-gfm": "^4.0.0",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "shiki": "^1.23.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@oramacloud/client": "1.x.x",
+        "algoliasearch": "4.24.0",
+        "next": "14.x.x || 15.x.x",
+        "react": ">= 18",
+        "react-dom": ">= 18"
+      },
+      "peerDependenciesMeta": {
+        "@oramacloud/client": {
+          "optional": true
+        },
+        "algoliasearch": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/@shikijs/core": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.23.1.tgz",
+      "integrity": "sha512-NuOVgwcHgVC6jBVH5V7iblziw6iQbWWHrj5IlZI3Fqu2yx9awH7OIQkXIcsHsUmY19ckwSgUMgrqExEyP5A0TA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/engine-javascript": "1.23.1",
+        "@shikijs/engine-oniguruma": "1.23.1",
+        "@shikijs/types": "1.23.1",
+        "@shikijs/vscode-textmate": "^9.3.0",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.3"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/@shikijs/engine-javascript": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.23.1.tgz",
+      "integrity": "sha512-i/LdEwT5k3FVu07SiApRFwRcSJs5QM9+tod5vYCPig1Ywi8GR30zcujbxGQFJHwYD7A5BUqagi8o5KS+LEVgBg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/types": "1.23.1",
+        "@shikijs/vscode-textmate": "^9.3.0",
+        "oniguruma-to-es": "0.4.1"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/@shikijs/engine-oniguruma": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.23.1.tgz",
+      "integrity": "sha512-KQ+lgeJJ5m2ISbUZudLR1qHeH3MnSs2mjFg7bnencgs5jDVPeJ2NVDJ3N5ZHbcTsOIh0qIueyAJnwg7lg7kwXQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/types": "1.23.1",
+        "@shikijs/vscode-textmate": "^9.3.0"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/@shikijs/types": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.23.1.tgz",
+      "integrity": "sha512-98A5hGyEhzzAgQh2dAeHKrWW4HfCMeoFER2z16p5eJ+vmPeF6lZ/elEne6/UCU551F/WqkopqRsr1l2Yu6+A0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^9.3.0",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
+      "integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/mdast-util-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.0.0.tgz",
+      "integrity": "sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/mdast-util-gfm-footnote": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.0.0.tgz",
+      "integrity": "sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.0.tgz",
+      "integrity": "sha512-Ub2ncQv+fwD70/l4ou27b4YzfNaCJOvyX4HxXU15m7mpYY+rjuWzsLIPZHJL253Z643RpbcP1oeIJlQ/SKW67g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/react-remove-scroll": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
+      "integrity": "sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/remark-gfm": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.0.tgz",
+      "integrity": "sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/shiki": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.23.1.tgz",
+      "integrity": "sha512-8kxV9TH4pXgdKGxNOkrSMydn1Xf6It8lsle0fiqxf7a1149K1WGtdOu3Zb91T5r1JpvRPxqxU3C2XdZZXQnrig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/core": "1.23.1",
+        "@shikijs/engine-javascript": "1.23.1",
+        "@shikijs/engine-oniguruma": "1.23.1",
+        "@shikijs/types": "1.23.1",
+        "@shikijs/vscode-textmate": "^9.3.0",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/fumadocs-core/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/fumadocs-mdx": {
       "version": "11.0.0",
       "license": "MIT",
@@ -22364,7 +22871,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -23086,7 +23592,7 @@
     },
     "node_modules/immutable": {
       "version": "4.3.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-cwd": {
@@ -25344,7 +25850,6 @@
     },
     "node_modules/jiti": {
       "version": "1.21.6",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -25886,7 +26391,6 @@
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -30443,7 +30947,6 @@
     },
     "node_modules/mz": {
       "version": "2.7.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -30758,9 +31261,9 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
-      "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-dir": {
       "version": "0.1.17",
@@ -31118,7 +31621,6 @@
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -31290,6 +31792,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.4.1.tgz",
+      "integrity": "sha512-rNcEohFz095QKGRovP/yqPIKc+nP+Sjs4YTHMv33nMePGKrq/r2eu9Yh4646M5XluGJsUnmwoXuiXE69KDs+fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^5.0.0",
+        "regex-recursion": "^4.2.1"
+      }
+    },
+    "node_modules/oniguruma-to-es/node_modules/regex": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-5.0.2.tgz",
+      "integrity": "sha512-/pczGbKIQgfTMRV0XjABvc5RzLqQmwqxLHdQao2RTXPk+pmTXB2P0IaUHYdYyk412YLwUIkaeMd5T+RzVgTqnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
       }
     },
     "node_modules/oniguruma-to-js": {
@@ -31988,7 +32510,6 @@
     },
     "node_modules/postcss-import": {
       "version": "15.1.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -32004,7 +32525,6 @@
     },
     "node_modules/postcss-js": {
       "version": "4.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -32215,7 +32735,6 @@
     },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
-      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -32239,7 +32758,6 @@
     },
     "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -33207,7 +33725,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -34192,7 +34709,6 @@
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -34731,6 +35247,21 @@
     },
     "node_modules/regex": {
       "version": "4.4.0",
+      "license": "MIT"
+    },
+    "node_modules/regex-recursion": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-4.2.1.tgz",
+      "integrity": "sha512-QHNZyZAeKdndD1G3bKAbBEKOSSK4KOHQrAJ01N1LJeb0SoH4DJIeFhp0uUpETgONifS4+P3sOgoA1dhzgrQvhA==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
@@ -35333,7 +35864,7 @@
     },
     "node_modules/rollup": {
       "version": "3.29.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -35581,7 +36112,7 @@
     },
     "node_modules/sass": {
       "version": "1.80.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -35600,7 +36131,7 @@
     },
     "node_modules/sass/node_modules/chokidar": {
       "version": "4.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -35614,7 +36145,7 @@
     },
     "node_modules/sass/node_modules/readdirp": {
       "version": "4.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.16.0"
@@ -36713,7 +37244,6 @@
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -36734,7 +37264,6 @@
     },
     "node_modules/sucrase/node_modules/commander": {
       "version": "4.1.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -36742,7 +37271,6 @@
     },
     "node_modules/sucrase/node_modules/glob": {
       "version": "10.4.5",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -36761,7 +37289,6 @@
     },
     "node_modules/sucrase/node_modules/jackspeak": {
       "version": "3.4.3",
-      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -36775,7 +37302,6 @@
     },
     "node_modules/sucrase/node_modules/minipass": {
       "version": "7.1.2",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -37085,7 +37611,6 @@
     },
     "node_modules/tailwindcss": {
       "version": "3.4.14",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -37129,7 +37654,6 @@
     },
     "node_modules/tailwindcss/node_modules/postcss-load-config": {
       "version": "4.0.2",
-      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -37163,7 +37687,6 @@
     },
     "node_modules/tailwindcss/node_modules/postcss-load-config/node_modules/lilconfig": {
       "version": "3.1.2",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -37174,7 +37697,6 @@
     },
     "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -37186,7 +37708,6 @@
     },
     "node_modules/tailwindcss/node_modules/yaml": {
       "version": "2.6.0",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -37393,7 +37914,7 @@
     },
     "node_modules/terser": {
       "version": "5.36.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -37487,7 +38008,7 @@
     },
     "node_modules/terser/node_modules/acorn": {
       "version": "8.14.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -37498,12 +38019,12 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -37511,7 +38032,7 @@
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -37581,7 +38102,6 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -37589,7 +38109,6 @@
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -37866,7 +38385,6 @@
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {


### PR DESCRIPTION
## Problem

The docs build started failing at the `postinstall` script, where it was unable to find `fumadocs-core`:

```
(base) saadbazaz@Saads-MacBook-Pro monorepo % npm i
npm error code 1
npm error path /Users/saadbazaz/Projects/monorepo/apps/docs
npm error command failed
npm error command sh -c fumadocs-mdx
npm error node:internal/modules/esm/resolve:839
npm error   throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
npm error         ^
npm error
npm error Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'fumadocs-core' imported from /Users/saadbazaz/Projects/monorepo/node_modules/fumadocs-mdx/dist/chunk-FXIX4XBC.mjs
npm error     at packageResolve (node:internal/modules/esm/resolve:839:9)
npm error     at moduleResolve (node:internal/modules/esm/resolve:908:18)
npm error     at defaultResolve (node:internal/modules/esm/resolve:1038:11)
npm error     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:557:12)
npm error     at ModuleLoader.resolve (node:internal/modules/esm/loader:525:25)
npm error     at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:246:38)
npm error     at ModuleJob._link (node:internal/modules/esm/module_job:126:49) {
npm error   code: 'ERR_MODULE_NOT_FOUND'
npm error }
npm error
npm error Node.js v22.9.0
npm error A complete log of this run can be found in: /Users/saadbazaz/.npm/_logs/2024-11-20T12_45_42_524Z-debug-0.log
```

This happened after the `package-lock.json` was updated in [this commit](https://github.com/UpstreetAI/monorepo/pull/616/commits/a269b72cf7e7e1719206c353fe2406717c83352e).

## Solution:
1. Install fumadocs-core in monorepo root: `npm i fumadocs-core`. This will add fumadocs-core to the root package lock, and hence the node_modules
2. Remove `fumadocs-core` from the root package.json
3. Run `npm i` again.

This probably fixed it temporarily. Our best way forward is probably to use pnpm or yarn, which can handle resolutions better in monorepos.