### PR TITLE
fix: accept array input for formatDiscordBotChannels

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features.mjs
@@ -64,8 +64,8 @@ export const defaultVoices = [
   },
 ];
 
-const formatDiscordBotChannels = (channels = '') => {
-  return channels.split(',').map(c => c.trim()).filter(Boolean);
+const formatDiscordBotChannels = (channels = []) => {
+  return channels.map(c => c.trim()).filter(Boolean);
 };
 
 export const featureSpecs = [


### PR DESCRIPTION
This PR fixes, the following issue:
https://github.com/orgs/UpstreetAI/projects/7/views/1?pane=issue&itemId=88084792&issue=UpstreetAI%7Cmonorepo%7C624

The channels schema is defined as an array of strings has this function is refactored to accept an array and process an array rather then a string