### PR TITLE
Fix DiscordBot component not found

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features.mjs
@@ -162,7 +162,7 @@ export const featureSpecs = [
       if (discord.token && channels.length > 0) {
         return [
           dedent`
-            <DiscordBot
+            <Discord
               token=${JSON.stringify(discord.token)}
               ${discord.channels ? `channels={${JSON.stringify(channels)}}` : ''}
             />


### PR DESCRIPTION
This PR fixes the DiscordBot exception:
https://github.com/orgs/UpstreetAI/projects/7/views/1?pane=issue&itemId=88085995&issue=UpstreetAI%7Cmonorepo%7C625

- updates the Discord component in the agent-features file