### PR TITLE
append image attachments when generated to the bots text

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -69,13 +69,25 @@ const bindOutgoing = ({
       message,
     } = e.data;
     const {
+      attachments,
+    } = message;
+    const {
       method,
       args,
     } = message;
     if (method === 'say') {
-      const {
+      let {
         text,
       } = args as { text: string };
+
+      if (attachments && Object.keys(attachments).length > 0) {
+        console.log('attachments: ', attachments);
+        const imageAttachment = Object.values(attachments).find(attachment => 
+          attachment.type.includes('image/')
+        );
+        text += `\n${imageAttachment.url}`;
+      }
+
       discordBotClient.input.writeText(text, {
         channelId,
         userId,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -75,17 +75,24 @@ const bindOutgoing = ({
       method,
       args,
     } = message;
+    console.log('e.data: ', e.data);
+
     if (method === 'say') {
       let {
         text,
       } = args as { text: string };
-
+      console.log('discord manager outgoing message', {
+        text,
+        attachments,
+        channelId,
+        userId,
+      });
+      
       if (attachments && Object.keys(attachments).length > 0) {
-        console.log('attachments: ', attachments);
-        const imageAttachment = Object.values(attachments).find(attachment => 
-          attachment.type.includes('image/')
-        );
-        text += `\n${imageAttachment.url}`;
+        text += '\n' + Object.values(attachments)
+          .filter(attachment => attachment && typeof attachment === 'object' && 'url' in attachment)
+          .map(attachment => attachment.url)
+          .join('\n');
       }
 
       discordBotClient.input.writeText(text, {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -75,18 +75,11 @@ const bindOutgoing = ({
       method,
       args,
     } = message;
-    console.log('e.data: ', e.data);
 
     if (method === 'say') {
       let {
         text,
       } = args as { text: string };
-      console.log('discord manager outgoing message', {
-        text,
-        attachments,
-        channelId,
-        userId,
-      });
       
       if (attachments && Object.keys(attachments).length > 0) {
         text += '\n' + Object.values(attachments)


### PR DESCRIPTION
This PRs appends generated attachment to the bots text response back to the user.

- Extract attachment
- append to text if image type

Although i believe any url type attachments should be added to the text message response (checking for generated video)

<img width="980" alt="image" src="https://github.com/user-attachments/assets/40ed5a91-e55d-4e63-9764-71fea17626fd">
